### PR TITLE
Add some user-data and an IAM instance profile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,6 @@
+v0.0.4:
+- Add some content to the readme.
+- Add an IAM instance profile that allows the Chef node to pull objects from a Chef bucket.
+- Move Chef configuration parameters to a "Chef Namespace"
+- Support version constraints when installing Chef Omnitruck package
+- Add UserData, which actually runs Chef client.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # sparkle-pack-cfn-init-chef
 CFN Init Registry to bootstrap an instance with Chef
+
+## iam_instance_profile dynamic
+
+Creates an IAM instance profile allowing the resource to fetch objects from the Chef bucket, mark itself unhealthy so that its parent auto scaling group can
+terminate and try launching a replacement Chef node, and signal CloudFormation to satisfy a stack creation policy.
+
+The creation policy specifies that CloudFormation must get as many success notifications as the desired capacity in an auto scaling group.
+
+_config[:policy_statements] = an array of hashes or symbols.  These objects will be passed to the SparkleFormation's registry! function, as a name, options pair
+in the case of a hash, or individually in the case of a symbol.  Basically, create a policy statement as a registry, and pass it in as "extra" policy 
+statements to attach to the IAM instance policy you're creating (i.e. modifying route53 entries).
+
+## user_data registry
+
+| Parameter | Purpose |
+|-----------|---------|
+| _config[:iam_role] | ref!(:your_iam_role) |
+| _config[:resource_id] | The logical name of your auto scaling group, as it appears in the compiled JSON template |
+| _config[:launch_config] | The logical name of your launch configuration, as it appears in the compiled JSON template |
+
+## chef_client registry
+
+You can pass ref!(...) objects or strings, mostly.
+
+| Parameter | Purpose |
+|-----------|---------|
+| _config[:chef_attributes] | Hash of Chef attributes |
+| _config[:chef_run_list] | Array of Chef run list items |
+| _config[:chef_bucket] | Chef bucket name (see https://github.com/gswallow/sparkle-pack-aws-my-s3-buckets) |
+| _config[:chef_environment] | ENV['environment'] by default |
+| _config[:chef_log_level] | :info by default |
+| _config[:chef_validation_client] | the validation client name |
+| _config[:chef_fail_on_reporting_errors] | false by default |
+| _config[:chef_version] | 'latest' by default |
+| _config[:iam_role] | ref!(:your_iam_role) |

--- a/lib/sparkleformation/dynamics/iam_instance_profile.rb
+++ b/lib/sparkleformation/dynamics/iam_instance_profile.rb
@@ -1,0 +1,69 @@
+SparkleFormation.dynamic(:iam_instance_profile) do |_name, _config = {}|
+
+  # Create an IAM Instance Profile, which basically binds together an IAM role allowing
+  # privilege escalation, and list of actions to allow elevated access to.
+  #
+  # Default actions are:
+  #
+  # cloudformation:DescribeStackResource on the instance's stack
+  # cloudformation:SignalResource on the instance's stack
+  # autoscaling:SetInstanceHealth on any ec2 instance in the instance's region
+  # s3:GetObject on anything in the Chef bucket
+  #
+  # Pass in a list of policy statements through _config[:policy_statements].
+
+  _config[:policy_statements] ||= []
+
+  dynamic!(:i_a_m_instance_profile, _name).properties do
+    path '/'
+    roles _array(
+            ref!("#{_name}_i_a_m_role".to_sym)
+          )
+  end
+  dynamic!(:i_a_m_instance_profile, _name).depends_on "#{_name.capitalize}IAMPolicy"
+
+  dynamic!(:i_a_m_role, _name).properties do
+    assume_role_policy_document do
+      version '2012-10-17'
+      statement _array(
+        -> {
+          effect 'Allow'
+          principal do
+            service _array( 'ec2.amazonaws.com' )
+          end
+          action _array( 'sts:AssumeRole' )
+        }
+      )
+    end
+    path '/'
+  end
+
+
+  # <shrug> http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#AutoScaling_ARN_Format
+  dynamic!(:i_a_m_policy, _name).properties do
+    policy_name 'chefValidatorKeyAccess'
+    policy_document do
+      version '2012-10-17'
+      statement _array(
+        *_config.fetch(:policy_statements, []).map { |s| s.is_a?(Hash) ? registry!(s.keys.first.to_sym, s.values.first) : registry!(s.to_sym) },
+        -> {
+          action %w(cloudformation:DescribeStackResource cloudformation:SignalResource)
+          resource join!( join!('arn', 'aws', 'cloudformation', region!, account_id!, 'stack', :options => { :delimiter => ':'}), stack_name!, stack_id!, :options => { :delimiter => '/' })
+          effect 'Allow'
+        },
+        -> {
+          action %w(autoscaling:SetInstanceHealth)
+          resource '*'
+          effect 'Allow'
+        },
+        -> {
+          action %w(s3:GetObject)
+          resource join!( join!( 'arn', 'aws', 's3', '', '', _config[:chef_bucket], :options => { :delimiter => ':' }), '*', :options => { :delimiter => '/' })
+          effect 'Allow'
+        }
+      )
+    end
+    roles _array( ref!("#{_name}_i_a_m_role".to_sym))
+  end
+  dynamic!(:i_a_m_policy, _name).depends_on "#{_name.capitalize}IAMRole"
+end

--- a/lib/sparkleformation/dynamics/iam_instance_profile.rb
+++ b/lib/sparkleformation/dynamics/iam_instance_profile.rb
@@ -12,8 +12,6 @@ SparkleFormation.dynamic(:iam_instance_profile) do |_name, _config = {}|
   #
   # Pass in a list of policy statements through _config[:policy_statements].
 
-  _config[:policy_statements] ||= []
-
   dynamic!(:i_a_m_instance_profile, _name).properties do
     path '/'
     roles _array(
@@ -48,7 +46,7 @@ SparkleFormation.dynamic(:iam_instance_profile) do |_name, _config = {}|
         *_config.fetch(:policy_statements, []).map { |s| s.is_a?(Hash) ? registry!(s.keys.first.to_sym, s.values.first) : registry!(s.to_sym) },
         -> {
           action %w(cloudformation:DescribeStackResource cloudformation:SignalResource)
-          resource join!( join!('arn', 'aws', 'cloudformation', region!, account_id!, 'stack', :options => { :delimiter => ':'}), stack_name!, stack_id!, :options => { :delimiter => '/' })
+          resource join!( join!('arn', 'aws', 'cloudformation', region!, account_id!, 'stack', :options => { :delimiter => ':'}), stack_name!, '*', :options => { :delimiter => '/' })
           effect 'Allow'
         },
         -> {

--- a/lib/sparkleformation/registry/chef_client.rb
+++ b/lib/sparkleformation/registry/chef_client.rb
@@ -68,7 +68,12 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
         command 'mkdir /var/log/chef'
         test 'test ! -e /var/log/chef'
       end
-      commands('02_chef_first_run') do
+      # Why is this still a problem, Chef?
+      commands('02_create_ec2_hints_file') do
+        command 'mkdir -p /etc/chef/ohai/hints && touch /etc/chef/ohai/hints/ec2.json'
+        test 'test ! -e /etc/chef/ohai/hints/ec2.json'
+      end
+      commands('03_chef_first_run') do
         command 'chef-client -j /etc/chef/first_run.json'
       end
     end

--- a/lib/sparkleformation/registry/chef_client.rb
+++ b/lib/sparkleformation/registry/chef_client.rb
@@ -1,20 +1,20 @@
 SfnRegistry.register(:chef_client) do |_name, _config={}|
 
-  chef_bucket = _config.fetch(:chef_bucket)
+  ENV['environment'] ||= '_default'
 
-  first_run = _config.fetch(:attributes, {}).merge(
+  first_run = _config.fetch(:chef_attributes, {}).merge(
     :stack => {
       :name => stack_name!,
       :id => stack_id!,
       :region => region!
     },
-    :run_list => _config.fetch(:run_list, [])
+    :run_list => _config.fetch(:chef_run_list, [])
   )
 
   metadata('AWS::CloudFormation::Authentication') do
     chef_s3_auth do
-      set!('roleName'._no_hump, _config.fetch(:auth_role))
-      set!('buckets'._no_hump, [ chef_bucket ])
+      set!('roleName'._no_hump, _config[:iam_role])
+      set!('buckets'._no_hump, [ _config[:chef_bucket] ])
       set!('type'._no_hump, 'S3')
     end
   end
@@ -27,17 +27,17 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
     chef_client do
       files('/etc/chef/validation.pem') do
         source join!(
-          'https://', chef_bucket, '.s3.amazonaws.com/', 'validation.pem'
+          'https://', _config[:chef_bucket] , '.s3.amazonaws.com/', 'validation.pem'
         )
         mode '000400'
         owner 'root'
         group 'root'
         authentication 'ChefS3Auth'
       end
-      if _config[:data_bag_secret]
+      if _config[:chef_data_bag_secret]
         files('/etc/chef/encrypted_data_bag_secret') do
           source join!(
-            'https://', chef_bucket, '.s3.amazonaws.com/', 'encrypted_data_bag_secret'
+            'https://', _config[:chef_bucket], '.s3.amazonaws.com/', 'encrypted_data_bag_secret'
           )
           mode '000400'
           owner 'root'
@@ -47,10 +47,12 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
       end
       files('/etc/chef/client.rb') do
         content join!(
-          "chef_server_url '#{_config.fetch(:chef_server)}'\n",
-          "environment '#{_config.fetch(:chef_environment, '_default')}'\n",
+          "chef_server_url '", _config[:chef_server], "'\n",
+          "environment '#{_config.fetch(:chef_environment, ENV['environment'])}'\n",
+          "log_level :#{_config.fetch(:chef_log_level, 'info').to_s}\n",
           "log_location '/var/log/chef/client.log'\n",
-          "validation_client_name '#{_config.fetch(:validation_client)}'\n"
+          "validation_client_name '", _config[:chef_validation_client], "'\n",
+          "enable_reporting_url_fatals #{_config.fetch(:chef_fail_on_reporting_errors, 'false')}\n"
         )
         mode '000400'
         owner 'root'
@@ -60,7 +62,7 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
         content first_run
       end
       commands('00_install_chef') do
-        command 'curl -L https://omnitruck.chef.io/install.sh | sudo bash'
+        command join!("curl -sSL https://omnitruck.chef.io/install.sh | sudo bash -s -- -v ", _config[:chef_version])
       end
       commands('01_log_dir') do
         command 'mkdir /var/log/chef'
@@ -68,10 +70,6 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
       end
       commands('02_chef_first_run') do
         command 'chef-client -j /etc/chef/first_run.json'
-      end
-      commands('03_remove_validation_pem') do
-        command 'rm /etc/chef/validation.pem'
-        test 'test -e /etc/chef/client.pem'
       end
     end
   end

--- a/lib/sparkleformation/registry/chef_client.rb
+++ b/lib/sparkleformation/registry/chef_client.rb
@@ -62,7 +62,7 @@ SfnRegistry.register(:chef_client) do |_name, _config={}|
         content first_run
       end
       commands('00_install_chef') do
-        command join!("curl -sSL https://omnitruck.chef.io/install.sh | sudo bash -s -- -v ", _config[:chef_version])
+        command join!("curl -sSL https://omnitruck.chef.io/install.sh | sudo bash -s -- -v ", _config.fetch(:chef_version, 'latest'))
       end
       commands('01_log_dir') do
         command 'mkdir /var/log/chef'

--- a/lib/sparkleformation/registry/user_data.rb
+++ b/lib/sparkleformation/registry/user_data.rb
@@ -1,0 +1,35 @@
+SfnRegistry.register(:user_data) do |_name, _config={}|
+
+  user_data base64!(
+    join!(
+      "#!/bin/bash\n\n",
+
+      "function my_instance_id\n",
+      "{\n",
+      "  curl -sL http://169.254.169.254/latest/meta-data/instance-id/\n",
+      "}\n\n",
+
+      "function cfn_signal_and_exit\n",
+      "{\n",
+      "  status=$?\n",
+      "  if [ $status -eq 0 ]; then\n",
+      "    /usr/local/bin/cfn-signal ",
+      "     --role ", _config[:iam_role],
+      "     --region ", region!,
+      "     --resource ", _config[:resource_id],
+      "     --stack ", stack_name!,
+      "     --exit-code $status\n",
+      "  else\n",
+      "    sleep 180\n",
+      "    /usr/local/bin/aws autoscaling set-instance-health --instance-id $(my_instance_id) --health-status Unhealthy --region ", region!, "\n",
+      "  fi\n",
+      "  exit $status\n",
+      "}\n\n",
+
+      "/usr/local/bin/cfn-init -s ", stack_name!, " --resource ", _config[:launch_config],
+      "  --region ", region!, " || cfn_signal_and_exit\n\n",
+
+      "cfn_signal_and_exit\n"
+    )
+  )
+end

--- a/sparkle-pack-cfn-init-chef.gemspec
+++ b/sparkle-pack-cfn-init-chef.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'sparkle-pack-cfn-init-chef'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.licenses = ['MIT']
   s.summary = 'CFN Init Chef SparklePack'
   s.description = 'SparklePack to provide cfn-init config set to bootstrap an instance using Chef'


### PR DESCRIPTION
Hiya,

This is a fairly large pull request; sorry about that. I added user-data to wrap around running Chef Client, as well as an IAM instance profile which allows the EC2 instance to signal its stack, mark itself unhealthy so its parent auto scaling group can zap it and replace it, and access the Chef bucket.

I closed the last PR because I needed to revert your recent commit switching from += to .concat so I created a "PR1" branch.

Thanks for your consideration.